### PR TITLE
pwm: Check duty cycle in embedded-hal impl

### DIFF
--- a/embassy-neorv32/CHANGELOG.md
+++ b/embassy-neorv32/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Check the duty cycle for PWM in embedded-hal implementation
 - Change DMA transfer size comments from 23 bits to 24 bits
 - Fix dual-hart CS acquire to return mie, not mstatus
 - Have TWI driver shift address before ORing R/W bit

--- a/embassy-neorv32/src/pwm.rs
+++ b/embassy-neorv32/src/pwm.rs
@@ -411,8 +411,12 @@ impl<'d> embedded_hal_1::pwm::SetDutyCycle for PwmChan<'d> {
     }
 
     fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
-        let percent = Percent::new(duty as u8)?;
-        self.set_duty_cycle(percent);
-        Ok(())
+        if duty > self.max_duty_cycle() {
+            Err(Error::InvalidDuty)
+        } else {
+            let percent = Percent::new(duty as u8)?;
+            self.set_duty_cycle(percent);
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
The embedded-hal PWM trait method expects a u16 for duty cycle, but we silently truncate it down to u8. Originally I was thinking the conversion to percent would catch this, but there's the case where user might provide for example 0xff00 which would truncate to 0x00, which `Percent::new()` would happily accept.