### PR TITLE
uart: Fix TX write_byte

### DIFF
--- a/embassy-neorv32/CHANGELOG.md
+++ b/embassy-neorv32/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix UART `write_byte` so it does a write, not modify of data reg
 - Check the duty cycle for PWM in embedded-hal implementation
 - Change DMA transfer size comments from 23 bits to 24 bits
 - Fix dual-hart CS acquire to return mie, not mstatus

--- a/embassy-neorv32/src/uart/mod.rs
+++ b/embassy-neorv32/src/uart/mod.rs
@@ -601,7 +601,7 @@ impl<'d, M: IoMode> UartTx<'d, M> {
         self.info
             .reg
             .data()
-            .modify(|_, w| unsafe { w.uart_data_rtx().bits(byte) });
+            .write(|w| unsafe { w.uart_data_rtx().bits(byte) });
     }
 
     fn enable_irq_tx_empty(&mut self) {


### PR DESCRIPTION
UART `write_byte` was originally doing a `modify`, but this has the side-effect of first reading from the data reg, which will drain a byte from the RX FIFO which we don't want. Instead we just do a `write` because the upper 24 bits are read-only.