### PR TITLE
use `portable-atomic` instead of `core::sync::atomic`

### DIFF
--- a/embassy-neorv32/Cargo.toml
+++ b/embassy-neorv32/Cargo.toml
@@ -28,6 +28,7 @@ neorv32-pac = { version = "0.2.0", path = "../neorv32-pac", features = [
 riscv = { version = "0.16.0" }
 riscv-rt = { version = "0.17.0", optional = true }
 critical-section = { version = "1.2.0" }
+portable-atomic = "1.13.1"
 defmt = { version = "1.0.1", optional = true }
 
 embassy-time-driver = { version = "0.2.1", optional = true }

--- a/embassy-neorv32/src/dma.rs
+++ b/embassy-neorv32/src/dma.rs
@@ -3,7 +3,7 @@ use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
 use crate::peripherals::DMA;
 use core::marker::PhantomData;
 use core::pin::Pin;
-use core::sync::atomic::{AtomicBool, Ordering, fence};
+use portable_atomic::{AtomicBool, Ordering, fence};
 use core::task::{Context, Poll};
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;

--- a/embassy-neorv32/src/dual_hart.rs
+++ b/embassy-neorv32/src/dual_hart.rs
@@ -196,8 +196,8 @@ mod ihc {
 
 mod cs {
     use super::*;
-    use core::sync::atomic::AtomicU8;
-    use core::sync::atomic::Ordering::{Acquire, Release};
+    use portable_atomic::AtomicU8;
+    use portable_atomic::Ordering::{Acquire, Release};
 
     // Need to track this since critical sections can be nested
     const LOCK_UNOWNED: u8 = 0;
@@ -244,8 +244,8 @@ mod cs {
     #[cfg(target_has_atomic = "ptr")]
     mod cs_impl {
         use super::*;
-        use core::sync::atomic::AtomicBool;
-        use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+        use portable_atomic::AtomicBool;
+        use portable_atomic::Ordering::{Acquire, Relaxed, Release};
 
         static LOCK: AtomicBool = AtomicBool::new(false);
 
@@ -279,8 +279,8 @@ mod cs {
     #[cfg(not(target_has_atomic = "ptr"))]
     mod cs_impl {
         use super::*;
-        use core::sync::atomic::Ordering::SeqCst;
-        use core::sync::atomic::{AtomicBool, AtomicUsize};
+        use portable_atomic::Ordering::SeqCst;
+        use portable_atomic::{AtomicBool, AtomicUsize};
 
         static TURN: AtomicUsize = AtomicUsize::new(0);
         static FLAG: [AtomicBool; NHARTS] = [const { AtomicBool::new(false) }; NHARTS];
@@ -312,8 +312,8 @@ mod cs {
 pub mod executor {
     use super::*;
     use core::marker::PhantomData;
-    use core::sync::atomic::AtomicBool;
-    use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+    use portable_atomic::AtomicBool;
+    use portable_atomic::Ordering::{Acquire, Relaxed, Release};
     use embassy_executor::{Spawner, raw};
 
     static SEV_FLAG: [AtomicBool; NHARTS] = [const { AtomicBool::new(false) }; NHARTS];

--- a/embassy-neorv32/src/uart/mod.rs
+++ b/embassy-neorv32/src/uart/mod.rs
@@ -7,7 +7,7 @@ use crate::peripherals::{UART0, UART1};
 use crate::sysinfo::SysInfo;
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, Ordering};
+use portable_atomic::{AtomicBool, Ordering};
 use core::task::Poll;
 use embassy_hal_internal::atomic_ring_buffer::RingBuffer;
 use embassy_hal_internal::{Peri, PeripheralType};


### PR DESCRIPTION
Hi,
core relies on atomic CAS for `core::sync::atomic`.
On Risc-V this requires the A-ISA-Extension.
The NEORV32 can be configured without the A-Extension. If you use the correct target that doesn't have atomic operations enabled, this crate won't build.
portable-atomic provides an alternative implementation if the A-Extension isn't available (e.g. by using a critical-section).

Cheers
Paul